### PR TITLE
Fix iOS background compatibility and improve background opacity handling

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -55,13 +55,14 @@ body {
 }
 
 // Ln 57-65: Apply background to html element for full viewport coverage
-// and so the background stays viewport-fixed during scrolling
+// Note: background-attachment: fixed is not used due to iOS Safari compatibility issues
 html {
-  -webkit-background-color: var(--theme-semantic-bodyBackground); // iOS fallback
+  -webkit-background-color: var(
+    --theme-semantic-bodyBackground
+  ); // iOS fallback
   background-color: var(--theme-semantic-bodyBackground); // Standard fallback
   background: var(--background); // Radial gradient (if set in theme)
-  background-attachment: fixed;
-  background-size: 100dvw 100dvh;
+  background-size: cover; // Changed from 100dvw 100dvh for iOS compatibility
   background-repeat: no-repeat;
   background-position: center;
 }

--- a/src/theme/components/layout/background-layer/background-layer.tsx
+++ b/src/theme/components/layout/background-layer/background-layer.tsx
@@ -141,7 +141,7 @@ export const BackgroundLayer: React.FC<BackgroundLayerProps> = ({
         height: '100dvh',
         zIndex: 1,
         overflow: 'hidden',
-        opacity: 1, // Always visible - backgroundLoaded animation handled by parent
+        opacity: backgroundLoaded ? 1 : 0, // Fade in when background image is loaded
         transition: shouldReduceMotion ? 'none' : 'opacity 0.5s ease-in-out',
       }}
     >


### PR DESCRIPTION
#82 had some SCSS that was incompatible with Mobile iOS. After doing further research, we found the hash where this occurred with a prior fix to the home page and video content. 

We removed and replaced the offending SCSS in globals.scss and added styling to remove the custom styles that Microsoft puts in on a div:body tag to not show its background so instead, it's from the HTML. We also fixed a minor bug with backgroundLoaded transitioning not set up properly in background-layer.tsx.