### PR TITLE
fix: remove unused networking configuration from staticwebapp.config.…

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -94,8 +94,5 @@
     "X-XSS-Protection": "1; mode=block",
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Permissions-Policy": "geolocation=(), microphone=(), camera=()"
-  },
-  "networking": {
-    "allowedIpRanges": []
   }
 }


### PR DESCRIPTION
fix: remove unused networking configuration from staticwebapp.config.json due to build errors on all envs

Static Web Apps Free SKU disabled networking JSON all of a sudden. Removing the block so the build will work again, as our Static Web Apps in Azure including Prod use Free SKUs.